### PR TITLE
Fix license and add keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
   "name": "mmm-mopidy-mpd",
   "version": "0.1.0",
-  "description": "Music Player Daemon for magic mirror",
+  "description": "Music Player Daemon for MagicMirror².",
   "main": "none",
+  "keywords": [
+    "MPD",
+    "music"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Maja Aurora Pieper",
-  "license": "MIT License",
+  "license": "MIT",
   "dependencies": {
     "mpd": "^1.3.0"
   }


### PR DESCRIPTION
License should be a valid [SPDX license expression](https://spdx.org/licenses/).

Keywords are used in the [new module list](https://kristjanesperanto.github.io/MagicMirror-3rd-Party-Modules/) I'm working on.